### PR TITLE
refactor models

### DIFF
--- a/src/base_model.py
+++ b/src/base_model.py
@@ -1,0 +1,92 @@
+import os
+from pathlib import Path
+from typing import Optional
+import sacrebleu
+from datasets import Dataset
+from tqdm import tqdm
+import torch.nn as nn
+
+class BaseTranslationModel:
+
+    def __init__(
+        self,
+        model_name: str,
+        src_language: str,
+        tgt_language: str,
+        model: Optional[nn.Module],
+        save_to_disk = True,
+    ):
+        self.model_name = model_name
+        self.src_language = src_language
+        self.tgt_language = tgt_language
+        self.model = model
+        self.dir_path = os.path.join("models", f"{model_name}-{src_language}-{tgt_language}/")
+        if not os.path.exists(self.dir_path):
+            os.makedirs(self.dir_path)
+
+        self.save_to_disk = save_to_disk
+
+
+    def translate(self, src_sentence: str):
+        raise NotImplementedError()
+    
+
+    def train(self):
+        raise NotImplementedError()
+    
+
+
+    @classmethod
+    def from_pretrained(self):
+        raise NotImplementedError()
+    
+    
+
+    def translate_test_data(self, test_dataset):
+        # TODO: improve caching so that multiple test sets can be cached
+        print(f"Computing translations from {self.src_language}-{self.tgt_language}.")
+
+        data_dir = os.path.join(self.dir_path, "data/")
+        if not os.path.exists(data_dir):
+            os.makedirs(data_dir)
+
+        
+        translation_file = os.path.join(data_dir, f"translations.{self.tgt_language}")
+
+        if os.path.exists(translation_file):
+            print(f"Translation file already exists. Skipping computation.")
+            return
+        
+        with open(translation_file, 'w') as translations:
+            for language_pair in tqdm(test_dataset['translation'], total=len(test_dataset)):
+                test_sentence = language_pair[self.src_language]
+                translations.write(self.translate(test_sentence) + "\n")
+
+            
+    def compute_bleu(self, test_dataset: Dataset):
+        # TODO: improve caching so that multiple test sets can be used
+        translation_file = os.path.join(self.dir_path, "data", f"translations.{self.tgt_language}")
+        if not os.path.exists(translation_file):
+            print(f"Could not find cached dataset at {translation_file}. Computing translations...")
+            self.translate_test_data(test_dataset)
+        
+        translations = Path(translation_file).read_text().strip().split("\n")
+        refs = [language_pair[self.tgt_language] for language_pair in test_dataset['translation']]
+        bleu = sacrebleu.metrics.BLEU()
+        return bleu.corpus_score(translations, [refs])
+
+        
+    def compute_chrf(self, test_dataset: Dataset):
+        translation_file = os.path.join(self.dir_path, "data", f"translations.{self.tgt_language}")
+        if not os.path.exists(translation_file):
+            print(f"Could not find cached dataset at {translation_file}. Computing translations...")
+            self.translate_test_data(test_dataset)
+        
+        translations = Path(translation_file).read_text().strip().split("\n")
+        refs = [language_pair[self.tgt_language] for language_pair in test_dataset['translation']]
+        return sacrebleu.corpus_chrf(translations, [refs])
+    
+    def print_stats(self, test_dataset: Dataset):
+        print(f"Translation model {self.model_name} trained on {self.src_language}-{self.tgt_language}:")
+        print(self.compute_bleu(test_dataset))
+        print(f"{self.compute_chrf(test_dataset)}\n")

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -1,4 +1,5 @@
 import os
+import datasets
 from datasets import Dataset, DatasetDict
 
 def make_splits(
@@ -96,11 +97,19 @@ def load_dataset(data_dir: str, translation_task: str, split=None):
     src_language, tgt_language = translation_task.split("-")
     splits = ["train", "validation", "test"] if not split else [split]
     data_dirs = [os.path.join(data_dir, split) for split in splits]
+        
+    try:
+        split_datasets = [
+            Dataset.from_dict(
+                {"translation": translations(data_dir, src_language, tgt_language)}
+            )
+            for data_dir in data_dirs
+        ]
+        dataset = DatasetDict(dict(zip(splits, split_datasets)))
+        
+    
+    except FileNotFoundError:
+        dataset = datasets.load_dataset(data_dir, translation_task)
 
-    datasets = [
-        Dataset.from_dict(
-            {"translation": translations(data_dir, src_language, tgt_language)}
-        )
-        for data_dir in data_dirs
-    ]
-    return DatasetDict(dict(zip(splits, datasets)))
+    dataset.data_dir = data_dir
+    return dataset

--- a/src/huggingface_model.py
+++ b/src/huggingface_model.py
@@ -1,35 +1,27 @@
 import os
-from pathlib import Path
-import sacrebleu
-from tqdm import tqdm
 import transformers
 from transformers import AutoModelForSeq2SeqLM, DataCollatorForSeq2Seq, Seq2SeqTrainingArguments, Seq2SeqTrainer, MarianMTModel, MarianConfig, GenerationConfig
+from datasets import Dataset
+from base_model import BaseTranslationModel
 
 
 
-
-class HuggingFaceTranslationModel:
+class HuggingFaceTranslationModel(BaseTranslationModel):
     def __init__(
         self,
         model_name: str,
         src_language: str,
         tgt_language: str,
-        dataset,
         tokenizer: transformers.PreTrainedTokenizer,
         model: transformers.PreTrainedModel,
+        save_to_disk = True,
         max_input_length: int = 128,
         max_target_length: int = 128,
     ):
-        self.model_name = model_name
-        self.src_language = src_language
-        self.tgt_language = tgt_language
-        self.dir_path = os.path.join("models", "hf", f"{model_name}-{self.src_language}-{self.tgt_language}")
-        self.dataset = dataset
+        super().__init__(model_name, src_language, tgt_language, model, save_to_disk)
         self.tokenizer = tokenizer
-        self.model = model
         self.max_input_length = max_input_length
         self.max_target_length = max_target_length
-        self._load_model()
 
 
     def translate(self, src_sentence: str):
@@ -37,49 +29,7 @@ class HuggingFaceTranslationModel:
         outputs = self.model.generate(inputs)
         translated_text = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
         return translated_text
-    
-    def translate_test_data(self):
-        print(f"Computing translations from {self.src_language}-{self.tgt_language}.")
 
-        data_dir = os.path.join(self.dir_path, "data/")
-        if not os.path.exists(data_dir):
-            os.makedirs(data_dir)
-        
-        translation_file = f"{data_dir}translations.{self.tgt_language}"
-
-        if os.path.exists(translation_file):
-            print(f"Translation file already exists. Skipping computation.")
-            return
-        
-        with open(translation_file, 'w') as translations:
-            for language_pair in tqdm(self.dataset['test']['translation'], total=len(self.dataset['test'])):
-                test_sentence = language_pair[self.src_language]
-                translations.write(self.translate(test_sentence) + "\n")
-
-    def compute_bleu(self):
-        translation_file = os.path.join(self.dir_path, f"data/translations.{self.tgt_language}")
-        if not os.path.exists(translation_file):
-            raise FileNotFoundError(f"Could not find translations file at path {translation_file}.")
-        
-        translations = Path(translation_file).read_text().strip().split("\n")
-        refs = [language_pair[self.tgt_language] for language_pair in self.dataset['test']['translation']]
-        bleu = sacrebleu.metrics.BLEU()
-        return bleu.corpus_score(translations, [refs])
-    
-    
-    def compute_chrf(self):
-        translation_file = os.path.join(self.dir_path, f"data/translations.{self.tgt_language}")
-        if not os.path.exists(translation_file):
-            raise FileNotFoundError(f"Could not find translations file at path {translation_file}.")
-        
-        translations = Path(translation_file).read_text().strip().split("\n")
-        refs = [language_pair[self.tgt_language] for language_pair in self.dataset['test']['translation']]
-        return sacrebleu.corpus_chrf(translations, [refs])
-    
-    def print_stats(self):
-        print(f"Translation model {self.model_name} trained on {self.src_language}-{self.tgt_language}:")
-        print(f"BLEU: {self.compute_bleu()}")
-        print(f"CHRF: {self.compute_chrf()}\n")
 
     def preprocess_function(self, data):
         inputs = [ex[self.src_language] for ex in data["translation"]]
@@ -110,8 +60,8 @@ class HuggingFaceTranslationModel:
             print(f"No cached model parameters found. Training model...")
             self._train()
 
-    def _train(self):
-        tokenized_datasets = self.dataset.map(self.preprocess_function, batched=True)
+    def train(self, dataset: Dataset):
+        tokenized_datasets = dataset.map(self.preprocess_function, batched=True)
         batch_size = 16
 
         args = Seq2SeqTrainingArguments(
@@ -136,5 +86,10 @@ class HuggingFaceTranslationModel:
         )
 
         trainer.train()
+        if self.save_to_disk:
+            trainer.save_model(self.dir_path)
 
-        trainer.save_model(self.dir_path)
+
+    @classmethod
+    def from_pretrained(cls, path):
+        return AutoModelForSeq2SeqLM.from_pretrained(path)

--- a/src/model.py
+++ b/src/model.py
@@ -1,35 +1,43 @@
-
+import json
 from typing import Union
 from architecture import *
 
 import copy
 import os
+from base_model import BaseTranslationModel
 from iterators import collate_batch_huggingface
 from testing_utils import SimpleLossCompute, greedy_decode
-from training_utils import Batch, DummyOptimizer, DummyScheduler, LabelSmoothing, TrainState, rate, run_epoch
+from training_utils import (
+    Batch,
+    DummyOptimizer,
+    DummyScheduler,
+    LabelSmoothing,
+    TrainState,
+    rate,
+    run_epoch,
+)
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim.lr_scheduler import LambdaLR
 import torch.multiprocessing as mp
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
-from datasets import IterableDatasetDict, DatasetDict
+from datasets import IterableDatasetDict, DatasetDict, Dataset
 from transformers import PreTrainedTokenizerBase, PreTrainedTokenizerFast
 from tokenizers import Tokenizer
 from tokenizers.models import BPE
 from tokenizers.trainers import BpeTrainer
 from tokenizers.pre_tokenizers import Whitespace
-from pathlib import Path
-import sacrebleu
 import GPUtil
 
-class TranslationModel:
+
+class TranslationModel(BaseTranslationModel):
     """
     A neural machine translator between a source and target language. Upon initialization, the translator
     will either fetched cached model parameters between the two languages or it will translate using parallel
     train, validation, and test data located within the models/{src}-{target}/data directory.
 
-    To initialize a new translation model on a language pair src-target, ensure that the models/{src}-{target}/data 
+    To initialize a new translation model on a language pair src-target, ensure that the models/{src}-{target}/data
     directory has files train.src, train.tgt, valid.src, valid.tgt, test.src, and test.tgt.
 
     PUBLIC API:
@@ -37,36 +45,37 @@ class TranslationModel:
     """
 
     def __init__(
-            self, 
-            model_name: str,
-            src_language: str, 
-            tgt_language: str,
-            dataset: Union[DatasetDict, IterableDatasetDict],
-            src_tokenizer: Optional[PreTrainedTokenizerBase] = None,
-            tgt_tokenizer: Optional[PreTrainedTokenizerBase] = None,
-            distributed = False,
-            save_to_disk = True,
-            N: int = 6,
-            d_model: int = 512,
-            d_ff: int = 2048,
-            heads: int = 8,
-            dropout: float = 0.1,
-            model_max_len: int =  5000,
-            **kwargs
-            ):
-        self.model_name = model_name
-        self.src_language = src_language
-        self.tgt_language = tgt_language
-        self.dir_path = os.path.join("models", f"{model_name}-{src_language}-{tgt_language}")
-        if not os.path.exists(self.dir_path):
-            os.path.makedirs(self.dir_path)
-        self.d_model = d_model
-        self.model_max_len = model_max_len
-        self.dataset = dataset
+        self,
+        model_name: str,
+        src_language: str,
+        tgt_language: str,
+        src_tokenizer: Optional[PreTrainedTokenizerBase] = None,
+        tgt_tokenizer: Optional[PreTrainedTokenizerBase] = None,
+        model: EncoderDecoder = None,
+        distributed=False,
+        save_to_disk=True,
+        N: int = 6,
+        d_model: int = 512,
+        d_ff: int = 2048,
+        heads: int = 8,
+        dropout: float = 0.1,
+        model_max_len: int = 5000,
+        **kwargs,
+    ):
+        super().__init__(model_name, src_language, tgt_language, model, save_to_disk)
         self.save_to_disk = save_to_disk
-
-        self.src_tokenizer = self._load_tokenizer(src_language) if not src_tokenizer else src_tokenizer
-        self.tgt_tokenizer = self._load_tokenizer(tgt_language) if not tgt_tokenizer else tgt_tokenizer
+        self.N = N
+        self.d_model = d_model
+        self.d_ff = d_ff
+        self.heads = heads
+        self.dropout = dropout
+        self.model_max_len = model_max_len
+        self.src_tokenizer = (
+            self._load_tokenizer(src_language) if not src_tokenizer else src_tokenizer
+        )
+        self.tgt_tokenizer = (
+            self._load_tokenizer(tgt_language) if not tgt_tokenizer else tgt_tokenizer
+        )
         self.add_special_tokens(self.src_tokenizer, self.tgt_tokenizer)
 
         self.src_vocab = self.src_tokenizer.get_vocab()
@@ -74,75 +83,41 @@ class TranslationModel:
         print(f"Initialized {src_language} vocab with {len(self.src_vocab)} tokens.")
         print(f"Initialized {tgt_language} vocab with {len(self.tgt_vocab)} tokens.")
 
-        self.architecture = self._make_architecture(N, d_model, d_ff, heads, dropout, model_max_len)
-        self._load_params(train_distributed = distributed)
-        
+        if not self.model:
+            self.model = self.__class__.make_model(
+                len(self.src_vocab), len(self.tgt_vocab), N, d_model, d_ff, heads, dropout, model_max_len
+            )
+
 
     def translate(self, src_sentence: str):
-        
         if not src_sentence or src_sentence.isspace():
             return src_sentence
-        
-        self.architecture.eval()
-        encoded = self.src_tokenizer(src_sentence, return_tensors = "pt")
+
+        self.model.eval()
+        encoded = self.src_tokenizer(src_sentence, return_tensors="pt")
         src = encoded["input_ids"]
         src_mask = (src != self.src_tokenizer.pad_token_id).unsqueeze(-2)
         out = greedy_decode(
-            self.architecture, 
-            src, 
-            src_mask, 
-            max_len=60, 
-            start_symbol=self.tgt_tokenizer.bos_token_id, 
-            end_symbol=self.tgt_tokenizer.eos_token_id
+            self.model,
+            src,
+            src_mask,
+            max_len=60,
+            start_symbol=self.tgt_tokenizer.bos_token_id,
+            end_symbol=self.tgt_tokenizer.eos_token_id,
         )
         return self.tgt_tokenizer.decode(out[0].tolist(), skip_special_tokens=True)
-    
-    def translate_test_data(self):
-        print(f"Computing translations from {self.src_language}-{self.tgt_language}.")
 
-        data_dir = os.path.join(self.dir_path, "data/")
-        if not os.path.exists(data_dir):
-            os.makedirs(data_dir)
-        
-        translation_file = f"{data_dir}translations.{self.tgt_language}"
-
-        if os.path.exists(translation_file):
-            print(f"Translation file already exists. Skipping computation.")
-            return
-        
-        with open(translation_file, 'w') as translations:
-            for language_pair in tqdm(self.dataset['test']['translation'], total=len(self.dataset['test'])):
-                test_sentence = language_pair[self.src_language]
-                translations.write(self.translate(test_sentence) + "\n")
-
-            
-    def compute_bleu(self):
-        translation_file = os.path.join(self.dir_path, f"data/translations.{self.tgt_language}")
-        if not os.path.exists(translation_file):
-            raise FileNotFoundError(f"Could not find translations file at path {translation_file}.")
-        
-        translations = Path(translation_file).read_text().strip().split("\n")
-        refs = [language_pair[self.tgt_language] for language_pair in self.dataset['test']['translation']]
-        bleu = sacrebleu.metrics.BLEU()
-        return bleu.corpus_score(translations, [refs])
-
-        
-    def compute_chrf(self):
-        translation_file = os.path.join(self.dir_path, f"data/translations.{self.tgt_language}")
-        if not os.path.exists(translation_file):
-            raise FileNotFoundError(f"Could not find translations file at path {translation_file}.")
-        
-        translations = Path(translation_file).read_text().strip().split("\n")
-        refs = [language_pair[self.tgt_language] for language_pair in self.dataset['test']['translation']]
-        return sacrebleu.corpus_chrf(translations, [refs])
-    
-    def print_stats(self):
-        print(f"Translation model {self.model_name} trained on {self.src_language}-{self.tgt_language}:")
-        print(f"BLEU: {self.compute_bleu()}")
-        print(f"CHRF: {self.compute_chrf()}\n")
-    
-    def _make_architecture(
-        self, N: int, d_model: int, d_ff: int, heads: int, dropout: float, model_max_len: int
+    @classmethod
+    def make_model(
+        cls,
+        len_src_vocab: int,
+        len_tgt_vocab: int,
+        N: int,
+        d_model: int,
+        d_ff: int,
+        heads: int,
+        dropout: float,
+        model_max_len: int,
     ):
         "Helper: Construct a model from hyperparameters."
         c = copy.deepcopy
@@ -152,9 +127,9 @@ class TranslationModel:
         architecture = EncoderDecoder(
             Encoder(EncoderLayer(d_model, c(attn), c(ff), dropout), N),
             Decoder(DecoderLayer(d_model, c(attn), c(attn), c(ff), dropout), N),
-            nn.Sequential(Embeddings(d_model, len(self.src_vocab)), c(position)),
-            nn.Sequential(Embeddings(d_model, len(self.tgt_vocab)), c(position)),
-            Generator(d_model, len(self.tgt_vocab)),
+            nn.Sequential(Embeddings(d_model, len_src_vocab), c(position)),
+            nn.Sequential(Embeddings(d_model, len_tgt_vocab), c(position)),
+            Generator(d_model, len_tgt_vocab),
         )
 
         # This was important from their code.
@@ -163,23 +138,50 @@ class TranslationModel:
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
         return architecture
-    
 
-    def _train(self, config):
+    def train(self, dataset: Dataset, config):
         print(f"Training translation model on {self.src_language}-{self.tgt_language}.")
         if config["distributed"]:
-            self._train_distributed_model(
-                config
-            )
+            self._train_distributed_model(config)
         else:
-            self._train_worker(
-                0, 1, config, False
+            self._train_worker(0, dataset, 1, config, False)
+
+    def save(self):
+        self.save_model_info()
+        torch.save(
+            self.model.state_dict(),
+            os.path.join(self.dir_path, "model_final.pt"),
         )
 
+    def save_model_info(self):
+        # Use for backwards compatibility
+        model_info = {
+            "len_src_vocab": len(self.src_vocab),
+            "len_tgt_vocab": len(self.tgt_vocab),
+            "N": self.N,
+            "d_model": self.d_model,
+            "d_ff": self.d_ff,
+            "heads": self.heads,
+            "dropout": self.dropout,
+            "model_max_len": self.model_max_len,
+        }
+        with open(os.path.join(self.dir_path, "model_info.json"), "w") as f:
+            json.dump(model_info, f)
+
+    @classmethod
+    def from_pretrained(cls, path: str):
+        print(f"Loading model from path {path}.")
+        model_info = json.load(open(os.path.join(path, "model_info.json"), "r"))
+        model = cls.make_model(**model_info)
+        model.load_state_dict(
+            torch.load(os.path.join(path, "model_final.pt"))
+        )
+        return model
+
     def _load_params(
-            self,
-            train_distributed: bool,
-        ):
+        self,
+        train_distributed: bool,
+    ):
         # TODO: cache models only for given hyperparameters
         # TODO: verify that distributed behavior works as intended
         config = {
@@ -197,11 +199,12 @@ class TranslationModel:
         if not os.path.exists(model_path):
             self._train(config)
             # set architecture back to CPU
-            self.architecture.to("cpu")
+            self.model.to("cpu")
         else:
             print(f"Using cached model parameters from path {model_path}.")
-            self.architecture.load_state_dict(torch.load(os.path.join(self.dir_path, "model_final.pt")))
-    
+            self.model.load_state_dict(
+                torch.load(os.path.join(self.dir_path, "model_final.pt"))
+            )
 
     def _load_tokenizer(self, language: str):
         tokenizer_path = os.path.join(self.dir_path, f"{language}_tokenizer.json")
@@ -209,12 +212,15 @@ class TranslationModel:
         if not os.path.exists(tokenizer_path):
             self._train_tokenizer(language)
 
-        tokenizer = PreTrainedTokenizerFast(tokenizer_file = tokenizer_path)
+        tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizer_path)
         tokenizer.model_max_length = self.model_max_len
         return tokenizer
-    
 
-    def add_special_tokens(self, src_tokenizer: PreTrainedTokenizerBase, tgt_tokenizer: PreTrainedTokenizerBase):
+    def add_special_tokens(
+        self,
+        src_tokenizer: PreTrainedTokenizerBase,
+        tgt_tokenizer: PreTrainedTokenizerBase,
+    ):
         for tokenizer in [src_tokenizer, tgt_tokenizer]:
             if not tokenizer.bos_token_id:
                 tokenizer.add_special_tokens({"bos_token": "[BOS]"})
@@ -223,52 +229,61 @@ class TranslationModel:
             if not tokenizer.pad_token_id:
                 tokenizer.add_special_tokens({"pad_token": "[PAD]"})
 
-
-    def _train_tokenizer(self, language: str, vocab_size = 10000):
-        
+    def _train_tokenizer(self, language: str, vocab_size=10000):
         print(f"Training new BPE tokenizer for language {language}.")
 
         data_path = f"{self.dir_path}data/train.{language}"
         if not os.path.exists(data_path):
-            raise FileNotFoundError(f"File {data_path} does not exist; could not train tokenizer on language {language}.")
+            raise FileNotFoundError(
+                f"File {data_path} does not exist; could not train tokenizer on language {language}."
+            )
 
         tokenizer = Tokenizer(BPE(unk_token="[UNK]"))
         tokenizer.pre_tokenizer = Whitespace()
-        trainer = BpeTrainer(vocab_size = vocab_size, special_tokens=["[UNK]", "[EOS]", "[BOS]", "[PAD]", "[MASK]"])
+        trainer = BpeTrainer(
+            vocab_size=vocab_size,
+            special_tokens=["[UNK]", "[EOS]", "[BOS]", "[PAD]", "[MASK]"],
+        )
 
         # Train the tokenizer
         tokenizer.train(files=[data_path], trainer=trainer)
         tokenizer.save(f"{self.dir_path}{language}_tokenizer.json")
 
-
     def _create_dataloaders(
         self,
+        dataset: Dataset,
         device,
         batch_size=12000,
         max_padding=128,
         is_distributed=True,
     ):
-
         def collate_fn(batch):
-            return collate_batch_huggingface(batch, self.src_language, self.tgt_language, self.src_tokenizer, self.tgt_tokenizer, device, max_padding)
-
+            return collate_batch_huggingface(
+                batch,
+                self.src_language,
+                self.tgt_language,
+                self.src_tokenizer,
+                self.tgt_tokenizer,
+                device,
+                max_padding,
+            )
 
         train_sampler = (
-            DistributedSampler(self.dataset['train']) if is_distributed else None
+            DistributedSampler(dataset["train"]) if is_distributed else None
         )
         valid_sampler = (
-            DistributedSampler(self.dataset['validation']) if is_distributed else None
+            DistributedSampler(dataset["validation"]) if is_distributed else None
         )
 
         train_dataloader = DataLoader(
-            self.dataset['train'],
+            dataset["train"],
             batch_size=batch_size,
             shuffle=(train_sampler is None),
             sampler=train_sampler,
             collate_fn=collate_fn,
         )
         valid_dataloader = DataLoader(
-            self.dataset['validation'],
+            dataset["validation"],
             batch_size=batch_size,
             shuffle=(valid_sampler is None),
             sampler=valid_sampler,
@@ -276,10 +291,10 @@ class TranslationModel:
         )
         return train_dataloader, valid_dataloader
 
-
     def _train_worker(
         self,
         gpu: int,
+        dataset: Dataset,
         ngpus_per_node: int,
         config,
         is_distributed: bool,
@@ -287,7 +302,7 @@ class TranslationModel:
         print(f"Train worker process using GPU: {gpu} for training", flush=True)
         torch.cuda.set_device(gpu)
         pad_idx = self.tgt_tokenizer.pad_token_id
-        model = self.architecture
+        model = self.model
         model.cuda(gpu)
         module = model
         is_main_process = True
@@ -305,6 +320,7 @@ class TranslationModel:
         criterion.cuda(gpu)
 
         train_dataloader, valid_dataloader = self._create_dataloaders(
+            dataset,
             gpu,
             batch_size=config["batch_size"] // ngpus_per_node,
             max_padding=config["max_padding"],
@@ -342,10 +358,13 @@ class TranslationModel:
 
             GPUtil.showUtilization()
             if is_main_process and self.save_to_disk:
-                checkpoint_dir = f"{self.dir_path}checkpoints/"
+                checkpoint_dir = os.path.join(self.dir_path, "checkpoints/")
                 if not os.path.exists(checkpoint_dir):
                     os.mkdir(checkpoint_dir)
-                file_path = f"{checkpoint_dir}%s%.2d.pt" % (config["file_prefix"], epoch)
+                file_path = f"{checkpoint_dir}%s%.2d.pt" % (
+                    config["file_prefix"],
+                    epoch,
+                )
                 torch.save(module.state_dict(), file_path)
             torch.cuda.empty_cache()
 
@@ -363,11 +382,7 @@ class TranslationModel:
             torch.cuda.empty_cache()
 
         if is_main_process and self.save_to_disk:
-            file_path = "%s%sfinal.pt" % (self.dir_path, config["file_prefix"])
-            torch.save(module.state_dict(), file_path)
-
-
-
+            self.save()
 
     def _train_distributed_model(self, config):
         ngpus = torch.cuda.device_count()
@@ -380,8 +395,3 @@ class TranslationModel:
             nprocs=ngpus,
             args=(ngpus, config, True),
         )
-
-
-
-
-


### PR DESCRIPTION
Refactor the separate translation models into a base class with common functionality.
Use `from_pretrained` syntax to separate model training from loading.

Closes #12, closes #10 